### PR TITLE
Update version of SonarCloud action

### DIFF
--- a/.github/workflows/quality_check_sonarcloud.yml
+++ b/.github/workflows/quality_check_sonarcloud.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install sonar-scanner
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
       - name: cmake
         run: |
           USE_LIBCMP=1 cmake .


### PR DESCRIPTION
## Motivation

The version of Java (11.0.17) used to run the analysis is deprecated, and SonarCloud no longer supports it.

## Proposed Changes

Update the GitHub action to sonarcloud-github-c-cpp@v2 which uses JRE 17.

## Test Plan

--