### PR TITLE
Switch CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,8 +255,8 @@ if(NOT DEFINED CPACK_PACKAGE_NAME)
 
 SET(CPACK_PACKAGE_NAME ${PROJECT_NAME})
 SET(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/siemens/gencmpclient")
-SET(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
-SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+SET(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
 SET(CPACK_PACKAGE_VENDOR "Siemens")
 set(CPACK_PACKAGE_CONTACT "David von Oheimb <David.von.Oheimb@siemens.com>")
 set(CPACK_PACKAGE_VERSION       ${GENCMPCLIENT_VERSION})
@@ -435,7 +435,7 @@ if(NOT YOCTO_BUILD)
         message(STATUS "fetching git submodule libsecutils")
         execute_process(COMMAND
           git submodule update ${GIT_PROGRESS} --init ${GIT_DEPTH} libsecutils
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           RESULT_VARIABLE GIT_SUBMODULE_RESULT
           )
         if(NOT GIT_SUBMODULE_RESULT EQUAL "0")
@@ -456,7 +456,7 @@ if(NOT YOCTO_BUILD)
         message(STATUS "fetching git submodule cmpossl")
         execute_process(COMMAND
           git submodule update ${GIT_PROGRESS} --init ${GIT_DEPTH} cmpossl
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           RESULT_VARIABLE GIT_SUBMODULE_RESULT
           )
         if(NOT GIT_SUBMODULE_RESULT EQUAL "0")


### PR DESCRIPTION
## Motivation

(Clarification: "main repository" refers to an unrelated repository that includes gencmpclient as a git submodule.)

Currently it is not possible to build the gencmpclient code when the gencmpclient repo is added as a submodule and included in the main repository's CMakeLists.txt via 

`add_subdirectory(gencmpclient)`

The build process fails because the `git submodule update` command will be executed with the working directory of the main repository, not the gencmpclient repository. Therefore, the submodules, like libsecutils, can not be found and the build process fails.

The build process also fails if the main repository does not contain either README.md or LICENSE.md, which will also be fixed by this PR.

## Proposed Changes

CMAKE_SOURCE_DIR should be changed to CMAKE_CURRENT_SOURCE_DIR within CMakeLists.txt.

## Test Plan

Run CMake and check if the project still builds. 
