### PR TITLE
`Makefile_v1`,`CMakeLists.txt`: use `git submodule --depth` option only if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,6 @@ set_target_properties(${LIBGENCMP_NAME} PROPERTIES
 
 find_package(Git)
 if(GIT_FOUND)
-  set(GIT_DEPTH --depth 1) # used to speed up getting submodules
   # add --progress if the tool supports it
   execute_process(COMMAND ${CMAKE_COMMAND} -E env LC_ALL=C ${GIT_EXECUTABLE} --help submodule
     OUTPUT_VARIABLE _TMP_HELP
@@ -157,6 +156,9 @@ if(GIT_FOUND)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   if("${_TMP_HELP}" MATCHES "--progress")
     set(GIT_PROGRESS "--progress") # gives lengthy output in CI runs
+  endif()
+  if("${_TMP_HELP}" MATCHES "--depth")
+    set(GIT_DEPTH --depth 1) # used to speed up getting submodules
   endif()
   if(DEFINED USE_LIBCMP)
     set(submodules libsecutils cmpossl)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,3 @@
 ALL COMPONENTS
 M:	David von Oheimb <David.von.Oheimb@siemens.com>
-M:	Andreas Kretschmer <Andreas.Kretschmer@siemens.com>
+M:	Rajeev Ranjan <Ranjan.Rajeev@siemens.com>

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -179,10 +179,14 @@ else
     endif
 endif
 
-ifeq ($(shell git help submodule | grep progress),)
+GIT_HELP=$(shell git help submodule)
+ifeq ($(findstring --progress,$(GIT_HELP)),)
     GIT_PROGRESS=
 else
     # GIT_PROGRESS=--progress # disabled as gives lengthy output in CI runs
+endif
+ifneq ($(findstring --depth,$(GIT_HELP)),)
+    GIT_DEPTH=--depth 1
 endif
 
 ################################################################
@@ -251,7 +255,7 @@ $(SECUTILS_OUT_LIB):
 
 .phony: update_secutils build_secutils
 update_secutils:
-	git submodule update $(GIT_PROGRESS) --init --depth 1 $(SECUTILS_DIR)
+	git submodule update $(GIT_PROGRESS) --init $(GIT_DEPTH) $(SECUTILS_DIR)
 build_secutils: # not: update_secutils
 	$(MAKE) -C $(SECUTILS_DIR) -f Makefile_v1 -s build_all $(SET_NDEBUG) $(SET_DEBUG_FLAGS) CFLAGS="$(CFLAGS) $(OSSL_VERSION_QUIRKS)" SECUTILS_USE_ICV=$(SECUTILS_USE_ICV) SECUTILS_USE_UTA=$(SECUTILS_USE_UTA) SECUTILS_NO_TLS=$(SECUTILS_NO_TLS) OPENSSL_DIR="$(OPENSSL_DIR)" OUT_DIR="$(OUT_DIR_REVERSE_DIR)"
 
@@ -273,7 +277,7 @@ endif
 
 .phony: update_cmpossl build_cmpossl
 update_cmpossl:
-	git submodule update $(GIT_PROGRESS) --init --depth 1 $(LIBCMP_DIR)
+	git submodule update $(GIT_PROGRESS) --init $(GIT_DEPTH) $(LIBCMP_DIR)
 build_cmpossl: # not: update_cmpossl
 	@ # the old way to build with CMP was: buildCMPforOpenSSL
 ifdef USE_LIBCMP

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ which is geared towards simple and interoperable industrial use.
 The software also provides a command-line interface (CLI)
 that is handy for interactive exploration of using CMP in a PKI.
 
+## Support model
+
+The [maintainers](MAINTAINERS) offer two levels of support.
+* Community support is provided on a best-effort basis
+  and can be requested via [issues](../../issues).
+* Paid professional support and consulting can be ordered
+  from Siemens by reaching out to the maintainers.
+
+[Contributions](CONTRIBUTING.md) are appreciated
+  in the form of [pull requests](../../pulls).
+
 
 ## Status and changelog
 


### PR DESCRIPTION
Fixes https://github.com/mpeylo/cmpossl/issues/244