### PR TITLE
Fix dependence on git for already checked out submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,7 @@ if(NOT YOCTO_BUILD)
 
   # find_package(secutils ${CPACK_PACKAGE_VERSION})
   if(NOT secutils_FOUND)
-    if(NOT EXISTS libsecutils/CMakeLists.txt)
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libsecutils/CMakeLists.txt")
       if(GIT_FOUND)
         message(STATUS "fetching git submodule libsecutils")
         execute_process(COMMAND
@@ -494,7 +494,7 @@ if(NOT YOCTO_BUILD)
 
   # find_package(cmp ${CPACK_PACKAGE_VERSION})
   if(DEFINED USE_LIBCMP AND NOT libcmp_FOUND)
-    if(NOT EXISTS cmpossl/CMakeLists.txt)
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmpossl/CMakeLists.txt")
       if(GIT_FOUND)
         message(STATUS "fetching git submodule cmpossl")
         execute_process(COMMAND


### PR DESCRIPTION
## Motivation

As the path provided to the if(NOT EXISTS) statement in the submodule section is not correct, the following statements will always be executed, as the files will never be found. This causes git to be used no matter what, even if the submodules are already checked out.

This PR fixes this issue by making the path dependent on ${CMAKE_CURRENT_SOURCE_DIR} and enclosing it in double quotes.

## Proposed Changes

Use ${CMAKE_CURRENT_SOURCE_DIR} to specify the path to the relevant submodule CMakeLists.txt

## Test Plan

Test that it still compiles. Notice that only on the first "cmake" call the submodules are fetched with this fix and the status message "-- fetching git submodule libsecutils" will not appear on subsequent calls.