### PR TITLE
introduce `GENCMP_NO_SECUTILS` and `GENCMP_NO_TLS`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,10 @@ jobs:
       - name: cmake
         run: |
           cmake .
-          make
-          make clean_all
+                                               make; make clean
+          GENCMP_NO_TLS=1                      make; make clean
+          GENCMP_NO_TLS=1 GENCMP_NO_SECUTILS=1 make; make clean
+                          GENCMP_NO_SECUTILS=1 make; make clean
 
           mkdir build
           cd build
@@ -23,6 +25,7 @@ jobs:
           cmake --build .
           cmake -DCMAKE_BUILD_TYPE=Release ..
           make clean build
+          DESTDIR=tmp make install uninstall
           cd ..
 
           mkdir build-with-libcmp
@@ -42,12 +45,18 @@ jobs:
           # would need access to azure.archive.ubuntu.com:
           # sudo apt-get update
           # sudo apt-get install -y >/dev/null libssl-dev build-essential # not needed
-          make -f Makefile_v1
-          USE_LIBCMP=1                 make -f Makefile_v1 clean build_no_tls
-          USE_LIBCMP=1 STATIC_LIBCMP=1 make -f Makefile_v1 clean build_no_tls
+                                               make -f Makefile_v1
+          GENCMP_NO_TLS=1                      make -f Makefile_v1 clean build
+          GENCMP_NO_TLS=1 GENCMP_NO_SECUTILS=1 make -f Makefile_v1 clean build
+                          GENCMP_NO_SECUTILS=1 make -f Makefile_v1 clean build
+
+          USE_LIBCMP=1                         make -f Makefile_v1 clean build
+          USE_LIBCMP=1 STATIC_LIBCMP=1         make -f Makefile_v1 clean build_no_tls
+
           make -C libsecutils -f Makefile_v1 clean_config
           SKIP_pod2markdown=1 DESTDIR=tmp make -f Makefile_v1 install uninstall
           make -f Makefile_v1 clean_all
+
   doc_deb:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,25 @@ message(STATUS "generic CMP client version " ${GENCMPCLIENT_VERSION})
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 # set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # needed for sonarCloud scanner when using CMake
 
+if(DEFINED ENV{GENCMP_NO_SECUTILS})
+  message(STATUS "will build without libSecUtils and CLI")
+  add_compile_definitions(GENCMP_NO_SECUTILS)
+  set(GENCMP_NO_SECUTILS 1)
+  set(GENCMP_NO_CLI 1)
+endif()
+
+if(DEFINED ENV{SECUTILS_NO_TLS})
+  set(GENCMP_NO_TLS 1)
+endif()
+if(DEFINED ENV{GENCMP_NO_TLS})
+  set(GENCMP_NO_TLS 1)
+endif()
+if(${GENCMP_NO_TLS})
+  message(STATUS "will build without TLS support")
+  add_compile_definitions(GENCMP_NO_TLS)
+  add_compile_definitions(SECUTILS_NO_TLS)
+endif()
+
 # improved from https://cmake.org/cmake/help/v3.6/module/FindOpenSSL.html
 if(NOT DEFINED OPENSSL_ROOT_DIR AND NOT "$ENV{OPENSSL_DIR}" STREQUAL "")
   get_filename_component(OPENSSL_ROOT_DIR "$ENV{OPENSSL_DIR}" ABSOLUTE)
@@ -20,7 +39,11 @@ if(NOT DEFINED OPENSSL_ROOT_DIR AND NOT "$ENV{OPENSSL_DIR}" STREQUAL "")
 endif()
 if(NOT DEFINED OPENSSL_FOUND) # not already done by superordinate module
   set(OPENSSL_VERSION "(unknown)")
-  set(OPENSSL_COMPONENTS COMPONENTS Crypto SSL) # TODO SSL should not be needed if SECUTILS_NO_TLS
+  if(${GENCMP_NO_TLS})
+    set(OPENSSL_COMPONENTS COMPONENTS Crypto)
+  else()
+    set(OPENSSL_COMPONENTS COMPONENTS Crypto SSL)
+  endif()
   # set(CMAKE_FIND_DEBUG_MODE TRUE)
   if(DEFINED OPENSSL_ROOT_DIR)
     find_package(OpenSSL HINTS "${OPENSSL_ROOT_DIR}" NO_DEFAULT_PATH ${OPENSSL_COMPONENTS})
@@ -139,6 +162,8 @@ else()
 endif()
 message(STATUS "build mode: ${CMAKE_BUILD_TYPE}")
 
+# must do add_compile_options() before add_library() and add_executable() see
+# https://stackoverflow.com/questions/40516794/cmake-not-applying-compile-option-using-add-compile-options
 add_compile_definitions(DEBUG_UNUSED)
 add_compile_definitions(PEDANTIC)
 add_compile_options(-pedantic) # -Werror is enabled only for development and CI, using Makefile_v1 without NDEBUG
@@ -146,8 +171,9 @@ add_compile_options(
   -Wall -Woverflow -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wswitch
   -Wsign-compare -Wformat -Wtype-limits -Wundef -Wconversion -Wunused-parameter)
 add_compile_options(-Wno-c99-extensions -Wno-language-extension-token -Wno-declaration-after-statement -Wno-expansion-to-defined)
-# because of libsecutils:
-add_compile_options(-Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-shadow)
+if(NOT DEFINED GENCMP_NO_SECUTILS)
+  add_compile_options(-Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-shadow)
+endif()
 # TODO maybe clean up code and re-enable property
 # set_property(TARGET ${LIBGENCMP_NAME} PROPERTY C_STANDARD 90)
 # set_property(TARGET cmpClient         PROPERTY C_STANDARD 90)
@@ -164,6 +190,7 @@ if(UNIX AND NOT APPLE AND CMAKE_BUILD_TYPE MATCHES Debug)
   target_link_libraries(${LIBGENCMP_NAME} ${COVERAGE_FLAGS})
 endif()
 
+if(NOT DEFINED GENCMP_NO_CLI)
 add_executable(cmpClient
   ${SRC_DIR}/cmpClient.c
   ${SRC_DIR}/credential_loading.h
@@ -176,23 +203,21 @@ target_link_libraries(cmpClient
   $<$<BOOL:${USE_LIBCMP}>:cmp>
   # important: libcmp before libcrypto such that its contents are preferred
   OpenSSL::Crypto
-  $<$<NOT:$<BOOL:$ENV{SECUTILS_NO_TLS}>>:OpenSSL::SSL>
+  $<$<NOT:$<BOOL:${GENCMP_NO_TLS}>>:OpenSSL::SSL>
 )
 if(DEFINED ENV{SECUTILS_USE_UTA})
   target_link_libraries(cmpClient uta)
   target_link_directories(cmpClient PRIVATE "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}") # usually expands to /usr/local/lib
 # set(CMAKE_INSTALL_RPATH "/usr/local/lib")
 endif()
-if(DEFINED ENV{SECUTILS_NO_TLS})
-  add_compile_definitions(SECUTILS_NO_TLS=1)
-endif()
+endif(NOT DEFINED GENCMP_NO_CLI)
 
 target_link_libraries(${LIBGENCMP_NAME}
-  security-utilities::library
+  $<$<NOT:$<BOOL:${GENCMP_NO_SECUTILS}>>:security-utilities::library>
   $<$<BOOL:${USE_LIBCMP}>:cmp>
   # important: libcmp before libcrypto such that its contents are preferred
   OpenSSL::Crypto
-  $<$<NOT:$<BOOL:$ENV{SECUTILS_NO_TLS}>>:OpenSSL::SSL>
+  $<$<NOT:$<BOOL:${GENCMP_NO_TLS}>>:OpenSSL::SSL>
 )
 
 set(INC_PUBLIC_HDRS
@@ -217,11 +242,13 @@ if(GIT_FOUND)
   if("${_TMP_HELP}" MATCHES "--depth")
     set(GIT_DEPTH --depth 1) # used to speed up getting submodules
   endif()
-  if(DEFINED USE_LIBCMP)
-    set(submodules libsecutils cmpossl)
-  else()
+
+  if(NOT DEFINED GENCMP_NO_SECUTILS)
     set(submodules libsecutils)
-    endif()
+  endif()
+  if(DEFINED USE_LIBCMP)
+    set(submodules ${submodules} cmpossl)
+  endif()
 
   add_custom_target(update
     COMMAND echo "updating repo and submodules"
@@ -256,8 +283,10 @@ install(FILES doc/Generic_CMP_client_API.pdf
   COMPONENT dev
   )
 
+if(NOT DEFINED GENCMP_NO_CLI)
 include(./Pod2Man)
 POD2MAN("${CMAKE_CURRENT_SOURCE_DIR}/doc" cmpClient 1 "${CMAKE_INSTALL_MANDIR}" bin)
+endif()
 
 install(TARGETS ${LIBGENCMP_NAME}
   LIBRARY
@@ -268,11 +297,13 @@ install(TARGETS ${LIBGENCMP_NAME}
     COMPONENT dev
 )
 
+if(NOT DEFINED GENCMP_NO_CLI)
 install(TARGETS cmpClient
   RUNTIME
   DESTINATION "${CMAKE_INSTALL_BINDIR}"
   COMPONENT bin
 )
+endif()
 
 if(NOT TARGET uninstall)
   add_custom_target(uninstall
@@ -356,7 +387,7 @@ set(CPACK_PACKAGE_VERSION_MINOR ${GENCMPCLIENT_VERSION_MINOR})
 set(CPACK_STRIP_FILES ON)
 
 set(CPACK_COMPONENT_LIB_DESCRIPTION "generic CMP client library
-Generic CMP client library based on OpenSSL and otionally libcmp
+Generic CMP client library based on OpenSSL and optionally libcmp
 With extended support for certficate status checking using CRLs and/or OCSP")
 set(CPACK_COMPONENT_DEV_DESCRIPTION "libgencmp C headers and documentation
 Development support for libgencmp and cmpclient")
@@ -382,7 +413,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(CPACK_DEB_COMPONENT_INSTALL ON)
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
   set(CPACK_DEBIAN_LIB_PACKAGE_NAME "${PROJECT_NAME}")
-  set(CPACK_DEBIAN_BIN_PACKAGE_NAME "cmpclient")
+  if(NOT DEFINED GENCMP_NO_CLI)
+    set(CPACK_DEBIAN_BIN_PACKAGE_NAME "cmpclient")
+  endif()
   set(CPACK_DEBIAN_DEV_PACKAGE_ARCHITECTURE "all")
   set(CPACK_DEBIAN_LIB_PACKAGE_SECTION "libs")
   set(CPACK_DEBIAN_DEV_PACKAGE_SECTION "devel")
@@ -395,13 +428,21 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   # to CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS or CMAKE_INSTALL_RPATH
 
   if(FALSE) # for now, disable dependencies to libs of subprojectx because their .so files for some reason already get included in the package:
-  if(DEFINED USE_LIBCMP)
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS
-      "libcmp (>= ${CPACK_PACKAGE_VERSION}), libsecutils (>= ${CPACK_PACKAGE_VERSION})")
-  else()
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsecutils (>= ${CPACK_PACKAGE_VERSION})")
-  endif()
-  endif()
+    if(NOT DEFINED GENCMP_NO_SECUTILS)
+      if(DEFINED USE_LIBCMP)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS
+            "libcmp (>= ${CPACK_PACKAGE_VERSION}), libsecutils (>= ${CPACK_PACKAGE_VERSION})")
+      else()
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsecutils (>= ${CPACK_PACKAGE_VERSION})")
+      endif()
+    else()
+      if(DEFINED USE_LIBCMP)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcmp (>= ${CPACK_PACKAGE_VERSION})")
+      else()
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
+      endif()
+    endif()
+  endif(FALSE)
 
   set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libgencmp (>= ${CPACK_PACKAGE_VERSION})")
   set(CPACK_DEBIAN_DEV_PACKAGE_SUGGESTS "libcmp-dev (>= ${CPACK_PACKAGE_VERSION}), libsecutils-dev (>= ${CPACK_PACKAGE_VERSION}), libssl-dev")
@@ -521,7 +562,7 @@ endmacro(add_clean_target)
 if(NOT YOCTO_BUILD)
 
   # find_package(secutils ${CPACK_PACKAGE_VERSION})
-  if(NOT secutils_FOUND)
+  if(NOT DEFINED GENCMP_NO_SECUTILS AND NOT secutils_FOUND)
     if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libsecutils/CMakeLists.txt")
       if(GIT_FOUND)
         message(STATUS "fetching git submodule libsecutils")

--- a/Makefile_src
+++ b/Makefile_src
@@ -7,6 +7,7 @@
 # Optional LIBCMP_INC defines the directory of the libcmp header files, must be non-empty if and only if libcmp is used (USE_LIBCMP).
 # All paths may be absolute or relative to the directory containing this Makefile.
 # With USE_LIBCMP, setting STATIC_LIBCMP leads to static linking with libcmp.a .
+# Optional GENCMP_NO_SECUTILS disables libSecUtils use, CLI, demos, and tests
 # Optional DEBUG_FLAGS may set to prepend to local CFLAGS and LDFLAGS (default see below).
 # OSSL_VERSION_QUIRKS maybe be needed to provide for setting OpenSSL compilation version quirks.
 
@@ -97,7 +98,9 @@ override CFLAGS += \
 override CFLAGS +=-Wno-c99-extensions -Wno-language-extension-token -Wno-declaration-after-statement -Wno-expansion-to-defined \
   -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-shadow # due to libsecutils
 ifeq ($(LPATH),)
-   override CFLAGS += -I$(SECUTILS_DIR)/src/libsecutils/include
+  ifndef GENCMP_NO_SECUTILS
+    override CFLAGS += -I$(SECUTILS_DIR)/src/libsecutils/include
+  endif
 endif
 ifneq ($(LIBCMP_INC),)
     ifeq ($(DEB_TARGET_ARCH),) # not during Debian packaging
@@ -124,15 +127,25 @@ ifneq ($(LIBCMP_INC),)
 endif
 # important: place libcmp before libcrypto such that its contents are preferred
 
-override LIBS += -lsecutils
+ifndef GENCMP_NO_SECUTILS
+    override LIBS += -lsecutils
+else
+    override CFLAGS += -DGENCMP_NO_SECUTILS=1
+endif
+
 ifdef SECUTILS_NO_TLS
-    override CFLAGS += -DSECUTILS_NO_TLS=1
+    GENCMP_NO_TLS=1
+endif
+ifdef GENCMP_NO_TLS
+    override CFLAGS += -DGENCMP_NO_TLS=1
 else
     override LIBS += -lssl
 endif
 override LIBS += -lcrypto
-ifdef SECUTILS_USE_UTA
+ifndef GENCMP_NO_SECUTILS
+  ifdef SECUTILS_USE_UTA
     override LIBS += -luta
+  endif
 endif
 
 override LDFLAGS += $(DEBUG_FLAGS) # needed for -fsanitize=...
@@ -157,14 +170,18 @@ ifeq ($(LPATH),)
         # endif
     endif
 #   not needed due to OUT_DIR set also for libsecutils and cmpossl:
-#   override LDFLAGS += -L $(SECUTILS_DIR)
+#   ifndef GENCMP_NO_SECUTILS
+#       override LDFLAGS += -L $(SECUTILS_DIR)
+#   endif
 #   ifneq ($(LIBCMP_INC),)
 #       override LDFLAGS += -L $(LIBCMP_DIR)
 #   endif
     ifeq ($(DEB_TARGET_ARCH),) # not during Debian packaging
         ifneq ($(PREFIX),)
 #           not needed due to OUT_DIR set also for libsecutils and cmpossl:
-#           override LDFLAGS += -Wl,-rpath,$(SECUTILS_DIR_)
+#           ifndef GENCMP_NO_SECUTILS
+#               override LDFLAGS += -Wl,-rpath,$(SECUTILS_DIR_)
+#           endif
 #           ifneq ($(LIBCMP_INC),)
 #               override LDFLAGS += -Wl,-rpath,$(LIBCMP_DIR_)
 #           endif
@@ -204,10 +221,14 @@ DEPS = $(SRCS:.c=.d)
 
 CMPCLIENT = $(PREFIX)$(BIN_DIR)/cmpClient$(EXE)
 
-ifeq ($(BIN_DIR),)
-BINARIES =
+ifdef GENCMP_NO_SECUTILS
+    BINARIES =
 else
-BINARIES = $(CMPCLIENT)
+    ifeq ($(BIN_DIR),)
+        BINARIES =
+    else
+        BINARIES = $(CMPCLIENT)
+    endif
 endif
 
 ########## rules and targets
@@ -219,8 +240,10 @@ ifeq ($(LPATH),)
 	@echo "Copying OpenSSL DLLs to base directory for convenient use with Windows"
 	@cp --preserve=timestamps $(OPENSSL_LIB)/$(OPENSSL_DLLS) $(PREFIX_DEST)
 endif
+ifndef GENCMP_NO_SECUTILS
 	@echo "Copying SecUtils DLL to base directory for convenient use with Windows"
 	@cp --preserve=timestamps $(SECUTILS_LIB) $(PREFIX_DEST) # $(OPENSSL_LIB)/*{crypto,ssl}*.dll
+endif
 endif
 
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)

--- a/Makefile_v1
+++ b/Makefile_v1
@@ -1,6 +1,8 @@
 #!/usr/bin/make
 
 # Optional USE_LIBCMP requires the use of the intermediate libcmp
+# Optional GENCMP_NO_SECUTILS disables libSecUtils use, CLI, demos, and tests
+# Optional GENCMP_NO_TLS disables SSL/TLS use
 # Optional LPATH defines where to find any pre-installed libsecutils and UTA libraries, e.g., /usr/lib
 # Optional OPENSSL_DIR defines where to find the OpenSSL installation
 #   with header files at include/openssl (default: will try, e.g., /usr).
@@ -9,7 +11,7 @@
 # Optional CFLAGS and LDFLAGS are appended by local settings.
 # Optional DEBUG_FLAGS may set to prepend to local CFLAGS and LDFLAGS. Also CFLAGS is passed to build goals.
 # Builds are done in release mode if optional NDEBUG is defined.
-# Optional OUT_DIR defines where libsecutils, libgencmp, and (optional) libcmp shall be placed (default: LPATH if set, otherwise '.').
+# Optional OUT_DIR defines where libsecutils (unless disabled), libgencmp, and (optional) libcmp shall be placed (default: LPATH if set, otherwise '.').
 # Optional BIN_DIR defines where the CLI application shall be placed (default: OUT_DIR)
 # Optional DESTDIR defines a prefix for the installation target directories.
 # Optional OPENSSL specifies the OpenSSL CLI application (including path) to use
@@ -269,15 +271,25 @@ default: $(OUT_DIR_BIN)
 $(OUT_DIR_BIN): | build # if $OUT_DIR_BIN already exists, would be nice not to run 'build'
 # but even the 'order-only' prerequisite does not prevent running 'build'
 
-ifdef SECUTILS_USE_ICV
-    export SECUTILS_USE_ICV=1
-endif
-ifdef SECUTILS_USE_UTA
-    export SECUTILS_USE_UTA=1
-endif
-ifdef SECUTILS_NO_TLS
+ifdef GENCMP_NO_TLS
+    export GENCMP_NO_TLS=1
     export SECUTILS_NO_TLS=1
 endif
+ifdef GENCMP_NO_SECUTILS
+    export GENCMP_NO_SECUTILS=1
+    export GENCMP_NO_CLI=1
+else
+  ifdef SECUTILS_USE_ICV
+    export SECUTILS_USE_ICV=1
+  endif
+  ifdef SECUTILS_USE_UTA
+    export SECUTILS_USE_UTA=1
+  endif
+  ifdef SECUTILS_NO_TLS
+    export GENCMP_NO_TLS=1
+    export SECUTILS_NO_TLS=1
+  endif
+endif # def GENCMP_NO_SECUTILS
 
 .phony: submodules
 ifneq ($(LPATH),)
@@ -289,7 +301,10 @@ submodules: build_submodules
 build_submodules: get_submodules build_secutils build_cmpossl
 # might use $(SECUTILS_LIB) $(LIBCMP_INC) instead but does not check for updates
 
+get_submodules:
+ifndef GENCMP_NO_SECUTILS
 get_submodules: $(SECUTILS_DIR)/src/libsecutils/include
+endif
 ifdef USE_LIBCMP
 get_submodules: $(LIBCMP_DIR)/include
 endif
@@ -299,6 +314,7 @@ update: update_secutils update_cmpossl
 	git rebase
 	git submodule update
 
+ifndef GENCMP_NO_SECUTILS
 $(SECUTILS_DIR)/src/libsecutils/include:
 	$(MAKE) -f Makefile_v1 update_secutils
 
@@ -310,15 +326,20 @@ else
 endif
 $(SECUTILS_OUT_LIB):
 	build_secutils
+endif
 
 .phony: update_secutils build_secutils
 update_secutils:
+ifndef GENCMP_NO_SECUTILS
 	git submodule update $(GIT_PROGRESS) --init $(GIT_DEPTH) $(SECUTILS_DIR)
 SECUTILS_FLAGS = SECUTILS_NO_TLS=$(SECUTILS_NO_TLS) \
     SECUTILS_USE_ICV=$(SECUTILS_USE_ICV) SECUTILS_USE_UTA=$(SECUTILS_USE_UTA)
+endif
 build_secutils: # not: update_secutils
+ifndef GENCMP_NO_SECUTILS
 	@ # cannot split line using '\' as Debian packaging cannot handle this
 	$(MAKE) -C $(SECUTILS_DIR) -f Makefile_v1 build_all $(SECUTILS_FLAGS) $(BUILD_SUBDIRS) $(BUILD_FLAGS) -s
+endif
 
 ifdef USE_LIBCMP
 $(LIBCMP_DIR)/include:
@@ -347,7 +368,9 @@ ifdef USE_LIBCMP
 endif
 
 clean_submodules:
+ifndef GENCMP_NO_SECUTILS
 	rm -rf $(SECUTILS_DIR) $(SECUTILS_OUT_LIB)*
+endif
 ifdef USE_LIBCMP
 	rm -rf $(LIBCMP_DIR) $(LIBCMP_OUT_LIB)*
 endif
@@ -368,11 +391,13 @@ ifeq ($(DEB_BUILD_ARCH),) # avoid weird syntax error on '\' with Debian packagin
 	    echo "WARNING: OpenSSL version '$$LIBCMP_OPENSSL_VERSION' used for building libcmp does not match '$(OPENSSL_VERSION)' to be used for building cmpClient"; \
 	fi
     endif
+    ifndef GENCMP_NO_SECUTILS
 	@export SECUTILS_OPENSSL_VERSION=`$(MAKE) -s 2>/dev/null --no-print-directory -f OpenSSL_version.mk SOURCE="$(SECUTILS_OUT_LIB)"` && \
 	if [[ "$$SECUTILS_OPENSSL_VERSION" != "$(OPENSSL_VERSION)" && \
 	      "$$SECUTILS_OPENSSL_VERSION" != "$(OPENSSL_MAJOR_VERSION)" ]]; then \
 	    echo "WARNING: OpenSSL version '$$SECUTILS_OPENSSL_VERSION' used for building libsecutils does not match '$(OPENSSL_VERSION)' to be used for building cmpClient"; \
 	fi
+    endif
 endif
 
 GENCMPCLIENT_CONFIG=include/genericCMPClient_config.h
@@ -394,14 +419,17 @@ endif
 BUILD_ONLY_DIRS = OUT_DIR="$(OUT_DIR)" BIN_DIR="$(BIN_DIR)" \
     LIB_NAME="$(OUTLIB)" VERSION="$(VERSION)" LIBCMP_INC="$(LIBCMP_INC)" \
     OPENSSL_DIR="$(OPENSSL_DIR)" OPENSSL_LIB="$(OPENSSL_LIB)" \
+    GENCMP_NO_SECUTILS=$(GENCMP_NO_SECUTILS) GENCMP_NO_TLS=$(GENCMP_NO_TLS) \
     INSTALL_DEB_PKGS=$(INSTALL_DEB_PKGS) DEB_TARGET_ARCH=$(DEB_TARGET_ARCH)
 build_only: $(GENCMPCLIENT_CONFIG)
 	@ # cannot split line using '\' as Debian packaging cannot handle this
 	$(MAKE) -f Makefile_src build $(BUILD_ONLY_DIRS) $(BUILD_FLAGS)
 
 build_no_tls:
+ifndef GENCMP_NO_SECUTILS
 	$(MAKE) -C $(SECUTILS_DIR) -f Makefile_v1 clean_config
-	$(MAKE) -f Makefile_v1 build $(BUILD_FLAGS) SECUTILS_NO_TLS=1
+endif
+	$(MAKE) -f Makefile_v1 build $(BUILD_FLAGS) GENCMP_NO_TLS=1
 
 
 # cleaning #####################################################################
@@ -447,6 +475,9 @@ clean_all: clean clean_deb
 	rm -fr Makefile CMakeCache.txt *.cmake CMakeFiles/
 	rm -f install_manifest*.txt compile_commands.json
 	rm -f doc/$(OUT_DOC) doc/cmpClient.md CMakeDoxyfile.in
+
+
+ifndef GENCMP_NO_CLI
 
 # get CRLs #####################################################################
 
@@ -740,11 +771,15 @@ test: clean build_no_tls
 	$(MAKE) -C $(SECUTILS_DIR) -f Makefile_v1 clean_config
 	@$(MAKE) -f Makefile_v1 clean $(OUT_DIR_BIN) demo_Insta $(BUILD_FLAGS)
 
+endif # ndef GENCMP_NO_CLI
+
 # doc and zip ##################################################################
 
 doc: doc_this get_submodules
+ifndef GENCMP_NO_SECUTILS
 	$(MAKE) -C $(SECUTILS_DIR) -f Makefile_v1 doc -s
         # not needed for cmpossl
+endif
 
 doc/$(OUT_DEV_DOC): doc/Generic_CMP_client_API.odt # to be done manually
 
@@ -778,7 +813,10 @@ zip:
 ## 'install' static libs to lib, headers to include, dynamic libs and bin to bin
 ################################################################
 
+
 # triggering build #############################################################
+
+ifndef GENCMP_NO_CLI
 
 ROOTDIR=$(PWD)
 TAR=$(SECUTILS_DIR)/tar
@@ -821,6 +859,7 @@ clean_openssl:
 .phony: buildCMPforOpenSSL
 buildCMPforOpenSSL: openssl ${makeCMPforOpenSSL_trigger}
 
+endif # ndef GENCMP_NO_CLI
 
 ################################################################
 # Debian packaging
@@ -834,10 +873,12 @@ deb: doc # just to make sure that transforming the doc files will work fine
 ifneq ($(INSTALL_DEB_PKGS),)
 deb: get_submodules
 ifeq ($(LPATH),)
-    ifneq ($(wildcard $(SECUTILS_DIR)),)
-        ifeq ($(shell dpkg -l | grep "ii  libsecutils "),)
-            $(MAKE) deb -C $(SECUTILS_DIR) -f Makefile_v1
-            sudo dpkg -i libsecutils{,-dev}_*.deb
+    ifndef GENCMP_NO_SECUTILS
+        ifneq ($(wildcard $(SECUTILS_DIR)),)
+            ifeq ($(shell dpkg -l | grep "ii  libsecutils "),)
+                $(MAKE) deb -C $(SECUTILS_DIR) -f Makefile_v1
+                sudo dpkg -i libsecutils{,-dev}_*.deb
+            endif
         endif
     endif
     ifdef USE_LIBCMP

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The [CHANGELOG.md](CHANGELOG.md) contains a coarse release history.
 The Generic CMP client API specification and CLI documentation
 are available in the [`doc`](doc/) folder.
 
-The Doxygen documentation of the underlying Security Utilities library is available
+The Doxygen documentation of the Security Utilities library is available
 via a link in its [README file](https://github.com/siemens/libsecutils/blob/master/README.md).
 
 ## Prerequisites
@@ -120,10 +120,11 @@ The following development and network tools are needed or recommended.
 The following OSS components are used.
 
 * OpenSSL development edition;
-  currently supported versions include 3.0, 3.1, 3.2, 3.3, 3.4
+  currently supported versions include 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6
   <!-- (formerly also versions 1.0.2, 1.1.0, and 1.1.1) -->
 * [Security Utilities (libsecutils)](https://github.com/siemens/libsecutils)
-  for support (not core) functionality needed mostly for the CLI
+  for support of (not core) functionality needed mostly for the CLI
+  unless the environment variable `GENCMP_NO_SECUTILS` is defined.
 * [CMPforOpenSSL](https://github.com/mpeylo/cmpossl),
   an intermediate CMP+CRMF+HTTP extension to OpenSSL,
   needed only if the OpenSSL version being used does not yet include
@@ -262,8 +263,9 @@ make -f Makefile_v1 get_submodules
 ```
 
 This will fetch also the underlying
-[CMPforOpenSSL extension to OpenSSL](https://github.com/mpeylo/cmpossl) if needed and
-the [Security Utilities (libsecutils)](https://github.com/siemens/libsecutils) library.
+[CMPforOpenSSL extension to OpenSSL](https://github.com/mpeylo/cmpossl) and
+the [Security Utilities (libsecutils)](https://github.com/siemens/libsecutils)
+library if needed.
 
 For using the project as a git submodule,
 do for instance the following in the directory where you want to integrate it:
@@ -372,7 +374,7 @@ not all of the CMP features newly defined in CMP Updates
 and in the Lightweight CMP Profile (LCMPP) are supported,
 which usually is not a problem.
 
-From use with the underlying Security Utilities library
+From use with the Security Utilities library
 the following environment variables may be set
 when calling `cmake` (at generation time) or when using `Makefile_v1`.
 
@@ -381,7 +383,7 @@ to be integrity protected with an Integrity Check Value (ICV),
 which may be produced using `util/icvutil`.
 * Use of the UTA library can be enabled by setting `SECUTILS_USE_UTA`.
   The UTA library must have been pre-installed on the system.
-* The TLS-related functions may be disabled by setting `SECUTILS_NO_TLS`,
+* The TLS-related functions may be disabled by setting `SECUTILS_NO_TLS` or `GENCMP_NO_TLS`,
   which also needs to be done when calling `make` at build time.
 
 ### Using CMake or `Makefile_v1`
@@ -630,9 +632,9 @@ for instance as given in the example outer [`Makefile.mk`](Makefile.mk).
 
 For compiling applications using the library,
 you will need to `#include` the header file [`genericCMPClient.h`](include/genericCMPClient.h)
-and add the directories [`include`](include/) and
-[`libsecutils/include`](
-https://github.com/siemens/libsecutils/blob/master/include/) to your C headers path.
+and add [`include`](include/) to your C headers path the directories.
+Unless `GENCMP_NO_SECUTILS` is set, also [`libsecutils/src/libsecutils/include`](
+https://github.com/siemens/libsecutils/blob/master/include/) needs to be added.
 When the intermediate library `libcmp` is used, you need to
 add also the directory [`cmpossl/include/cmp`](
 https://github.com/mpeylo/cmpossl/tree/cmp/include/cmp/),
@@ -675,5 +677,5 @@ LocalWords:  libcrypto sed zshrc LDFLAGS lib CPPFLAGS SECUTILS lsecutils CMPv
 LocalWords:  util icvutil NDEBUG DCMAKE ln usr libgencmp CC lssl lcmp md bis
 LocalWords:  cmpClient src DESTDIR ROOTFS cmpclient tarball deb rpath
 LocalWords:  debhelper dh devscripts debuild dpkg ecparam FI cr lgencmp cc cnf
-LocalWords:  genkey insta ref cmd newkey certout noout creds Wl ICV
+LocalWords:  genkey insta ref cmd newkey certout noout creds Wl ICV GENCMP
 -->

--- a/include/genericCMPClient_util.h
+++ b/include/genericCMPClient_util.h
@@ -1,0 +1,124 @@
+/*-
+ * @file   genericCMPClient_util.h
+ * @brief  generic CMP client library helper declarations
+ *
+ * @author David von Oheimb, Siemens AG, David.von.Oheimb@siemens.com
+ *
+ *  Copyright (c) 2024 Siemens AG
+ *  Licensed under the Apache License 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  You can obtain a copy in the file LICENSE in the source distribution
+ *  or at https://www.openssl.org/source/license.html
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GENERIC_CMP_CLIENT_UTIL_H
+# define GENERIC_CMP_CLIENT_UTIL_H
+
+# include <openssl/err.h>
+
+/* basic.h: */
+# define OPTIONAL /*!< marker for non-required parameter, i.e., null pointer allowed */
+# ifndef __cplusplus
+typedef enum {
+    false = 0,
+    true = 1
+} bool; /*!< Boolean value */
+# endif
+typedef struct credentials CREDENTIALS;
+
+/* util.h: */
+# define OPENSSL_V_3_0_0 0x30000000L
+# define UTIL_setup_openssl(version, build_name) /* no-op */
+
+/* log.h: */
+extern BIO *bio_err; /* for low-level error output if verbosity >= LOG_DEBUG */
+extern BIO *bio_trace; /* for detailed debugging output if verbosity >= LOG_TRACE */
+typedef OSSL_CMP_severity severity;
+# define LOG_EMERG   0  /*!< A panic condition was reported to all processes */
+# define LOG_ALERT   1  /*!< A condition that should be corrected immediately */
+# define LOG_CRIT    2  /*!< A critical condition */
+# define LOG_ERR     3  /*!< An error message */
+# define LOG_WARNING 4  /*!< A warning message */
+# define LOG_NOTICE  5  /*!< A condition requiring special handling */
+# define LOG_INFO    6  /*!< A general information message */
+# define LOG_DEBUG   7  /*!< A message useful for debugging programs */
+# define LOG_TRACE   8  /*!< A verbose message useful for detailed debugging */
+# define LOG_FUNC_FILE_LINE OPENSSL_FUNC, OPENSSL_FILE, OPENSSL_LINE
+# define FL_EMERG LOG_FUNC_FILE_LINE, LOG_EMERG  /*!< panic condition reported to all processes. */
+# define FL_ALERT LOG_FUNC_FILE_LINE, LOG_ALERT  /*!< condition to be corrected immediately. */
+# define FL_FATAL FL_ALERT                       /*!< condition to be corrected immediately. */
+# define FL_CRIT LOG_FUNC_FILE_LINE, LOG_CRIT    /*!< critical condition. */
+# define FL_ERR LOG_FUNC_FILE_LINE, LOG_ERR      /*!< error message. */
+# define FL_WARN LOG_FUNC_FILE_LINE, LOG_WARNING /*!< warning message. */
+# define FL_NOTE LOG_FUNC_FILE_LINE, LOG_NOTICE  /*!< condition requiring special handling. */
+# define FL_INFO LOG_FUNC_FILE_LINE, LOG_INFO    /*!< general information message. */
+# define FL_DEBUG LOG_FUNC_FILE_LINE, LOG_DEBUG  /*!< message useful for debugging. */
+# define FL_TRACE LOG_FUNC_FILE_LINE, LOG_TRACE  /*!< verbose message for detailed debugging. */
+typedef bool (*LOG_cb_t)(OPTIONAL const char *func, OPTIONAL const char *file,
+                         int lineno, severity level, const char *msg);
+void LOG_init(OPTIONAL LOG_cb_t log_fn);
+void LOG_set_name(OPTIONAL const char *name);
+void LOG_set_verbosity(severity level);
+bool LOG(OPTIONAL const char *func, OPTIONAL const char *file,
+         int lineno, severity level, const char *fmt, ...);
+bool LOG_console(OPTIONAL const char *func, OPTIONAL const char *file,
+                 int lineno, severity level, const char *msg);
+# define LOG_alert(msg) LOG(FL_ALERT, msg) /*!< simple alert message */
+# define LOG_err(msg) LOG(FL_ERR, msg)     /*!< simple error message */
+# define LOG_warn(msg) LOG(FL_WARN, msg)   /*!< simple warning message */
+# define LOG_info(msg) LOG(FL_INFO, msg)   /*!< simple information message */
+# define LOG_debug(msg) LOG(FL_DEBUG, msg) /*!< simple debug message */
+# define LOG_trace(msg) LOG(FL_TRACE, msg) /*!< simple trace message */
+
+/* credentials.h: */
+struct credentials
+{
+    OPTIONAL EVP_PKEY *pkey;        /*!< can refer to HW key store via engine */
+    OPTIONAL X509 *cert;            /*!< related certificate */
+    OPTIONAL STACK_OF(X509) *chain; /*!< intermediate/extra certs for cert */
+    OPTIONAL char *pwd;             /*!< alternative password (shared secret) */
+    OPTIONAL char *pwdref;          /*!< reference identifying the password */
+} /* CREDENTIALS */;
+CREDENTIALS *CREDENTIALS_new(OPTIONAL const EVP_PKEY *pkey, OPTIONAL const X509 *cert,
+                             OPTIONAL const STACK_OF(X509)  *chain, OPTIONAL const char *pwd,
+                             OPTIONAL const char *pwdref);
+void CREDENTIALS_free(OPTIONAL CREDENTIALS *creds);
+
+/* credentials.c: */
+# define CREDENTIALS_get_pkey(creds)   (creds)->pkey
+# define CREDENTIALS_get_cert(creds)   (creds)->cert
+# define CREDENTIALS_get_chain(creds)  (creds)->chain
+# define CREDENTIALS_get_pwd(creds)    (creds)->pwd
+# define CREDENTIALS_get_pwdref(creds) (creds)->pwdref
+
+/* files.h: */
+static const char *const sec_PASS_STR = "pass:";
+
+/* cert.h: */
+X509_NAME *UTIL_parse_name(const char *dn, int chtype, bool multirdn);
+# define CERTS_free(certs) sk_X509_pop_free(certs, X509_free)
+bool CERT_check_all(const char *uri, OPTIONAL STACK_OF(X509) *certs, int type_CA,
+                    OPTIONAL const X509_VERIFY_PARAM *vpm); /* used by CMPclient_caCerts() */
+
+/* store.h: */
+# ifndef GENCMP_NO_TLS
+bool STORE_set1_host_ip(X509_STORE *ts, OPTIONAL const char *name, OPTIONAL const char *ip);
+const char *STORE_get0_host(const X509_STORE *store);
+/* would be needed only with CREDENTIALS_print_cert_verify_cb(): */
+#  define STORE_EX_check_index() true
+#  define STORE_set0_tls_bio(store, bio) true
+# endif
+X509_STORE *STORE_create(OPTIONAL X509_STORE *store, OPTIONAL const X509 *cert,
+                         OPTIONAL const STACK_OF(X509) *certs);
+# define STORE_free(store) X509_STORE_free(store)
+
+# ifndef GENCMP_NO_TLS
+/* conn.h: */
+#  define CONN_IS_IP_ADDR(host) ((host) != NULL && ((*(host) >= '0' && *(host) <= '9') || *(host) == '[')) // TODO improve
+
+/* tls.h: */
+#  define TLS_init() true /* initialize OpenSSL's SSL lib, no needed at least since 3.0 */
+# endif
+
+#endif /* GENERIC_CMP_CLIENT_UTIL_H */

--- a/src/cmpClient.c
+++ b/src/cmpClient.c
@@ -24,6 +24,8 @@
 #include <secutils/connections/conn.h> /* for CONN_IS_HTTPS */
 #include <secutils/credentials/verify.h>
 #include <secutils/certstatus/crl_mgmt.h> /* for CRLMGMT_load_crl_cb */
+#include <secutils/credentials/credentials.h> /* for CERT{,S}_save and CERTS_free */
+#include <secutils/credentials/cert.h> /* for UTIL_parse_name */
 
 #ifdef LOCAL_DEFS
 # include "genericCMPClient_use.h"
@@ -484,7 +486,7 @@ opt_t cmp_opts[] = {
     OPT_END
 };
 
-#ifndef SECUTILS_NO_TLS
+#ifndef GENCMP_NO_TLS
 static int SSL_CTX_add_extra_chain_free(SSL_CTX *ssl_ctx, STACK_OF(X509) *certs)
 {
     int i;
@@ -543,7 +545,7 @@ static int set_gennames(OSSL_CMP_CTX *ctx, char *names, const char *desc)
 
 static SSL_CTX *setup_TLS(STACK_OF(X509) *untrusted_certs)
 {
-#ifdef SECUTILS_NO_TLS
+#ifdef GENCMP_NO_TLS
     (void)untrusted_certs;
     LOG_err("TLS is not enabled in this build");
     return NULL;
@@ -1371,7 +1373,7 @@ static int setup_transfer(CMP_CTX *ctx)
                                (int)opt_keep_alive, (int)opt_msg_timeout,
                                tls, opt_proxy, opt_no_proxy);
 
-#ifndef SECUTILS_NO_TLS
+#ifndef GENCMP_NO_TLS
     TLS_free(tls);
 #endif
     if (err != CMP_OK) {

--- a/src/genericCMPClient_util.c
+++ b/src/genericCMPClient_util.c
@@ -1,0 +1,630 @@
+/*-
+ * @file   genericCMPClient_util.c
+ * @brief  generic CMP client library helper implementation
+ *
+ * @author David von Oheimb, Siemens AG, David.von.Oheimb@siemens.com
+ *
+ *  Copyright (c) 2024 Siemens AG
+ *
+ *  Licensed under the Apache License 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  You can obtain a copy in the file LICENSE in the source distribution
+ *  or at https://www.openssl.org/source/license.html
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+/* util.c: */
+
+static
+void UTIL_erase_mem(void *dst, size_t len)
+{
+    if (dst != NULL)
+        OPENSSL_cleanse(dst, len);
+}
+
+static
+void UTIL_cleanse(char *str)
+{
+    if (str != NULL)
+        UTIL_erase_mem((void *)str, strlen(str));
+}
+
+static
+void UTIL_cleanse_free(OPTIONAL char *str)
+{
+    UTIL_cleanse(str);
+    OPENSSL_free(str);
+}
+
+/* log.c: */
+
+#include <syslog.h>
+
+static const char *const GENCMP_NAME = "genCMPClient";
+static const size_t loc_len = 256;
+
+/*!< these variables are shared between threads */
+static LOG_cb_t LOG_fn = 0;
+static const char *app_name = GENCMP_NAME;
+static severity verbosity = LOG_WARNING;
+BIO *bio_err = 0;
+BIO *bio_trace = 0;
+
+static void log_close_bios(void)
+{
+    if (bio_trace != NULL) {
+        (void)BIO_flush(bio_trace);
+        BIO_free(bio_trace);
+        bio_trace = NULL;
+    }
+    if (bio_err != NULL) {
+        (void)BIO_flush(bio_err);
+        BIO_free(bio_err);
+        bio_err = NULL;
+    }
+}
+
+static
+void LOG_close(void)
+{
+    log_close_bios();
+}
+
+void LOG_init(OPTIONAL LOG_cb_t log_fn)
+{
+    LOG_close(); /* flush any pending output and free any previous resources */
+
+    if (log_fn != NULL)
+        LOG_fn = log_fn;
+}
+
+void LOG_set_verbosity(severity level)
+{
+    if (level < LOG_EMERG || level > LOG_TRACE) {
+        fprintf(stderr, "error: logging verbosity level %d out of range (0 .. 8) for %s\n",
+                level, app_name);
+        return;
+    }
+
+    log_close_bios();
+
+    verbosity = level;
+
+#ifndef NDEBUG
+    if (level >= LOG_ERR) {
+        bio_err = BIO_new_fp(stderr, BIO_NOCLOSE);
+        if (bio_err == NULL)
+            fprintf(stderr, "warning: cannot open bio_err for low-level error reporting of %s\n",
+                    app_name);
+    }
+    if (level >= LOG_TRACE) {
+        bio_trace = BIO_new_fp(stdout, BIO_NOCLOSE);
+        if (bio_trace == NULL)
+            fprintf(stderr, "warning: cannot open bio_trace for detailed debugging output of %s\n",
+                    app_name);
+    }
+#endif
+}
+
+void LOG_set_name(OPTIONAL const char *name)
+{
+    app_name = name != NULL ? name : GENCMP_NAME;
+}
+
+static
+bool LOG_generic(OPTIONAL const char *func, OPTIONAL const char *file, int lineno,
+                 severity level, const char *msg, bool use_syslog, bool use_console)
+{
+    if (level > verbosity
+#ifdef NDEBUG
+        /* output DEBUG level messages only if debugging is enabled at build time */
+        || level >= LOG_DEBUG
+#endif
+        )
+        return true;
+
+    if (func == NULL)
+        func = "(no function)";
+    if (file == NULL)
+        file = "(no file)";
+    if (msg == NULL) /* just in case */
+        msg = "(no message)";
+
+    if (use_syslog)
+        syslog(level, "%s: %.50s():%.60s:%d: %.256s", app_name, func, file, lineno, msg);
+
+    if (!use_console)
+        return true;
+
+    /* print everything to stdout in order to prevent order mismatch with portions on stderr */
+    FILE *fd = /* level <= LOG_WARNING ? stderr : */ stdout;
+
+    char loc[loc_len];
+    memset(loc, 0x00, loc_len);
+#ifndef NDEBUG
+    int len = snprintf(loc, sizeof(loc), "%s", app_name);
+    /* print fct name, source file name, and lineno only if debugging is enabled at build time */
+    (void)snprintf(loc + len, sizeof(loc) - len, ":%s():%s:%d:", func, file, lineno);
+#endif
+
+    /* print string corresponding to level */
+    char *lvl = 0;
+    switch (level) {
+    case LOG_EMERG:
+        lvl = "EMERGENCY";
+        break;
+    case LOG_ALERT:
+        lvl = "ALERT";
+        break;
+    case LOG_CRIT:
+        lvl = "CRITICAL";
+        break;
+    case LOG_ERR:
+        lvl = "ERROR";
+        break;
+    case LOG_WARNING:
+        lvl = "WARNING";
+        break;
+    case LOG_NOTICE:
+        lvl = "NOTICE";
+        break;
+    case LOG_INFO:
+        lvl = "INFO";
+        break;
+    case LOG_DEBUG:
+        lvl = "DEBUG";
+        break;
+    case LOG_TRACE:
+        lvl = "TRACE";
+        break;
+    default:
+        lvl = "(UNKNOWN SEVERITY)";
+        break;
+    }
+
+    /* print message, making sure that newline is printed  */
+    size_t msg_len = strlen(msg);
+    const int msg_nl = msg_len > 0 && msg[msg_len - 1] == '\n';
+    const int ret = fprintf(fd, "%s %s: %s%s", loc, lvl, msg, msg_nl ? "" : "\n");
+
+    /* make sure that printing is done right away, return info on success  */
+    return fflush(fd) != EOF && ret >= 0;
+}
+
+static
+bool LOG_default(OPTIONAL const char *func, OPTIONAL const char *file,
+                 int lineno, severity level, const char *msg)
+{
+    return LOG_generic(func, file, lineno, level, msg, 1, 1);
+}
+
+bool LOG_console(OPTIONAL const char *func, OPTIONAL const char *file,
+                 int lineno, severity level, const char *msg)
+{
+    return LOG_generic(func, file, lineno, level, msg, 0, 1);
+}
+
+/*
+ * Function used for outputting error/warn/debug messages depending on callback.
+ * If no specific callback function is set, the function LOG_default() is used.
+ */
+bool LOG(OPTIONAL const char *func, OPTIONAL const char *file,
+         int lineno, severity level, const char *fmt, ...)
+{
+    va_list arg_ptr;
+    char msg[1024];
+    bool res;
+
+    va_start(arg_ptr, fmt);
+    BIO_vsnprintf(msg, sizeof(msg), fmt, arg_ptr);
+    res = (LOG_fn ? *LOG_fn : &LOG_default)(func, file, lineno, level, msg);
+    va_end(arg_ptr);
+    return res;
+}
+
+/* cert.c: */
+
+/*
+ * dn is expected to be in the format "/type0=value0/type1=value1/type2=..."
+ * where characters may be escaped by '\'.
+ * The NULL-DN may be given as "/" or "".
+ */
+/* adapted from OpenSSL:apps/lib/apps.c */
+X509_NAME *UTIL_parse_name(const char *dn, int chtype, bool multirdn)
+{
+    size_t buflen = strlen(dn) + 1; /*
+                                     * to copy the types and values.
+                                     * Due to escaping, the copy can only become shorter
+                                     */
+    char *buf = OPENSSL_malloc(buflen);
+    size_t max_ne = buflen / (1 + 1) + 1; /* maximum number of name elements */
+    const char **ne_types = OPENSSL_malloc(max_ne * sizeof(char *));
+    char **ne_values = OPENSSL_malloc(max_ne * sizeof(char *));
+    int *mval = OPENSSL_malloc(max_ne * sizeof(int));
+    const char *sp = dn;
+    char *bp = buf;
+    int i, ne_num = 0;
+    X509_NAME *n = 0;
+    int nid;
+
+    if (buf == NULL || ne_types == NULL || ne_values == NULL || mval == NULL) {
+        LOG_err("Malloc error");
+        goto error;
+    }
+
+    /* no multi-valued RDN by default */
+    mval[ne_num] = 0;
+
+    if (*sp != '\0' && *sp++ != '/') { /* skip leading '/' */
+        LOG(FL_ERR, "DN '%s' does not start with '/'.", dn);
+        goto error;
+    }
+
+    while (*sp != '\0') {
+        /* collect type */
+        ne_types[ne_num] = bp;
+        /* parse element name */
+        while (*sp != '=') {
+            if (*sp == '\\') { /* is there anything to escape in the * type...? */
+                if (*++sp != '\0') {
+                    *bp++ = *sp++;
+                } else {
+                    LOG(FL_ERR, "Escape character at end of DN '%s'", dn);
+                    goto error;
+                }
+            } else if (*sp == '\0') {
+                LOG(FL_ERR, "End of string encountered while processing type of DN '%s' element #%d",
+                    dn, ne_num);
+                goto error;
+            } else {
+                *bp++ = *sp++;
+            }
+        }
+        sp++;
+        *bp++ = '\0';
+        /* parse element value */
+        ne_values[ne_num] = bp;
+        while (*sp != '\0') {
+            if (*sp == '\\') {
+                if (*++sp != '\0') {
+                    *bp++ = *sp++;
+                } else {
+                    LOG(FL_ERR, "Escape character at end of DN '%s'", dn);
+                    goto error;
+                }
+            } else if (*sp == '/') { /* start of next element */
+                sp++;
+                /* no multi-valued RDN by default */
+                mval[ne_num + 1] = 0;
+                break;
+            } else if (*sp == '+' && multirdn) {
+                /* a not escaped + signals a multi-valued RDN */
+                sp++;
+                mval[ne_num + 1] = -1;
+                break;
+            } else {
+                *bp++ = *sp++;
+            }
+        }
+        *bp++ = '\0';
+        ne_num++;
+    }
+
+    if ((n = X509_NAME_new()) == NULL)
+        goto error;
+
+    for (i = 0; i < ne_num; i++) {
+        if ((nid = OBJ_txt2nid(ne_types[i])) == NID_undef) {
+            LOG(FL_WARN, "DN '%s' attribute %s has no known NID, skipped", dn, ne_types[i]);
+            continue;
+        }
+
+        if (ne_values[i] == NULL) {
+            LOG(FL_WARN, "No value provided for DN '%s' attribute %s, skipped", dn, ne_types[i]);
+            continue;
+        }
+
+        if (!X509_NAME_add_entry_by_NID(n, nid, chtype,
+                                        (unsigned char *)ne_values[i], -1, -1, mval[i])) {
+            ERR_print_errors(bio_err);
+            LOG(FL_ERR, "Error adding name attribute '/%s=%s'", ne_types[i], ne_values[i]);
+            X509_NAME_free(n);
+            n = 0;
+            goto error;
+        }
+    }
+
+error:
+    OPENSSL_free(ne_values);
+    OPENSSL_free(ne_types);
+    OPENSSL_free(mval);
+    OPENSSL_free(buf);
+    return n;
+}
+
+static void cert_msg(OPTIONAL const char *func, OPTIONAL const char *file, int lineno,
+                     severity level, const char *uri, X509 *cert, const char *msg)
+{
+    char *subj = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
+
+    LOG(func, file, lineno, level, "Certificate from '%s' with subject '%s' %s", uri, subj, msg);
+    OPENSSL_free(subj);
+}
+
+static
+bool CERT_check(const char *uri, OPTIONAL X509 *cert, int type_CA,
+                OPTIONAL const X509_VERIFY_PARAM *vpm)
+{
+    if (cert == NULL)
+        return true;
+    int res = 0;
+
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0
+    res = X509_cmp_timeframe(vpm, X509_get0_notBefore(cert),
+                             X509_get0_notAfter(cert));
+#else
+    unsigned long flags = vpm == NULL ? 0 :
+        X509_VERIFY_PARAM_get_flags((X509_VERIFY_PARAM *)vpm);
+    if ((flags & X509_V_FLAG_NO_CHECK_TIME) == 0) {
+        time_t ref_time;
+        time_t *time = NULL;
+
+        if ((flags & X509_V_FLAG_USE_CHECK_TIME) != 0) {
+            ref_time = X509_VERIFY_PARAM_get_time(vpm);
+            time = &ref_time;
+        }
+        if (X509_cmp_time(X509_get0_notAfter(cert), time) < 0)
+            res = 1;
+        else if (X509_cmp_time(X509_get0_notBefore(cert), time) > 0)
+            res = -1;
+    }
+#endif
+    bool ret = res == 0;
+    severity level = vpm == NULL ? LOG_WARNING : LOG_ERR;
+    if (!ret)
+        cert_msg(LOG_FUNC_FILE_LINE, level,
+                 uri, cert, res > 0 ? "has expired" : "not yet valid");
+    uint32_t ex_flags = X509_get_extension_flags(cert);
+    if (type_CA >= 0 && (ex_flags & EXFLAG_V1) == 0) {
+        bool is_CA = (ex_flags & EXFLAG_CA) != 0;
+
+        if ((type_CA == 1) != is_CA) {
+            cert_msg(LOG_FUNC_FILE_LINE, level, uri, cert,
+                     is_CA ? "is not an EE cert" : "is not a CA cert");
+            ret = false;
+        }
+    }
+    return ret;
+}
+
+bool CERT_check_all(const char *uri, OPTIONAL STACK_OF(X509) *certs, int type_CA,
+                    OPTIONAL const X509_VERIFY_PARAM *vpm)
+{
+    int i;
+    bool ret = true;
+
+    for (i = 0; i < sk_X509_num(certs /* may be NULL */); i++)
+        ret = CERT_check(uri, sk_X509_value(certs, i), type_CA, vpm)
+            && ret; /* Having 'ret' after the '&&', all certs are checked. */
+    return ret;
+}
+
+/* credentials.c: */
+
+CREDENTIALS *CREDENTIALS_new(OPTIONAL const EVP_PKEY *pkey, const OPTIONAL X509 *cert,
+                             OPTIONAL const STACK_OF(X509)  *chain, OPTIONAL const char *pwd,
+                             OPTIONAL const char *pwdref)
+{
+    const char *pass = pwd;
+    CREDENTIALS *res;
+
+    if (pwd != NULL && strncmp(pwd, sec_PASS_STR, strlen(sec_PASS_STR)) == 0)
+        pass = pwd + strlen(sec_PASS_STR);
+
+    if (pkey != NULL && cert != NULL && !X509_check_private_key((X509 *)cert, (EVP_PKEY *)pkey)) {
+        LOG_err("Private key and public key in cert do not match");
+        return NULL;
+    }
+
+    res = OPENSSL_malloc(sizeof(*res));
+    if (res == NULL) {
+        LOG(FL_ERR, "Out of memory");
+        return NULL;
+    }
+
+    res->pkey = (EVP_PKEY *)pkey;
+    if (pkey != NULL && !EVP_PKEY_up_ref(res->pkey))
+        res->pkey = NULL;
+    res->cert = (X509 *)cert;
+    if (cert != NULL && !X509_up_ref(res->cert))
+        res->cert = NULL;
+    res->chain = NULL;
+    if (chain != NULL)
+        res->chain = X509_chain_up_ref((STACK_OF(X509)*)chain);
+    res->pwd = OPENSSL_strdup(pass);
+    res->pwdref = OPENSSL_strdup(pwdref);
+
+    if ((pkey != NULL && res->pkey == NULL)
+        || (cert != NULL && res->cert == NULL)
+        || (chain != NULL && res->chain == NULL)
+        || (pass != NULL && res->pwd == NULL)
+        || (pwdref != NULL && res->pwdref == NULL)) {
+        CREDENTIALS_free(res);
+        LOG(FL_ERR, "Out of memory");
+        res = NULL;
+    }
+    return res;
+}
+
+void CREDENTIALS_free(OPTIONAL CREDENTIALS *creds)
+{
+    if (creds != NULL) {
+        EVP_PKEY_free(creds->pkey);
+        X509_free(creds->cert);
+        CERTS_free(creds->chain);
+        UTIL_cleanse_free(creds->pwd);
+        OPENSSL_free(creds->pwdref);
+        OPENSSL_free(creds);
+    }
+}
+
+/* all params may be null pointer; does not consume cert or certs */
+X509_STORE *STORE_create(OPTIONAL X509_STORE *store, OPTIONAL const X509 *cert,
+                         OPTIONAL const STACK_OF(X509) *certs)
+{
+    int i;
+
+    if (store == NULL) {
+#ifndef GENCMP_NO_TLS
+        if (!STORE_EX_check_index())
+            return 0;
+#endif
+
+        store = X509_STORE_new();
+        if (store == NULL)
+            goto oom;
+    }
+    X509_STORE_set_verify_cb(store, X509_STORE_CTX_print_verify_cb
+                             /* could be more informative: CREDENTIALS_print_cert_verify_cb */);
+
+#ifdef SECUTILS_TRUST_DEFAULT_STORE /* better not trust unclear default store */
+    if (X509_STORE_set_default_paths(store) != 1) {
+        LOG_err("Cannot load the system-wide trusted certificates");
+        STORE_free(store);
+        return 0;
+    }
+#endif
+
+    int n = certs ? sk_X509_num(certs) : 0;
+    for (i = cert ? -1 : 0; i < n; i++) {
+        if (i != -1)
+            cert = sk_X509_value(certs, i);
+        if (!X509_STORE_add_cert(store, (X509 *)cert)) {
+            STORE_free(store);
+            goto oom;
+        }
+    }
+    return store;
+
+oom:
+    LOG_err("Out of memory creating trust store");
+    return 0;
+}
+
+#ifndef GENCMP_NO_TLS
+
+/* conn.c: */
+
+static const char *const CONN_scheme_postfix = "://";
+
+static const char *skip_scheme(const char *str)
+{
+    const char *scheme_end = strstr(str, CONN_scheme_postfix);
+
+    if (scheme_end != NULL)
+        str = scheme_end + strlen(CONN_scheme_postfix);
+    return str;
+}
+
+static char *CONN_get_host(const char *uri)
+{
+    char *str = NULL;
+
+    if (uri != NULL) {
+        char *end;
+        size_t len;
+
+        uri = skip_scheme(uri);
+        end = strrchr(uri, ':');
+        if (end == NULL)
+            end = strchr(uri, '/');
+        len = end != NULL ? (size_t)(end - uri) : strlen(uri);
+        str = OPENSSL_strndup(uri, len);
+        if (str == NULL)
+            LOG_err("Out of memory");
+    }
+    return str;
+}
+
+/* store.c: */
+
+/* with GENCMP_NO_SECUTILS, not supported before 3.0: */
+# define STORE_set1_host(store, host) (OPENSSL_VERSION_NUMBER >= OPENSSL_V_3_0_0)
+
+bool STORE_set1_host_ip(X509_STORE *ts, OPTIONAL const char *name, OPTIONAL const char *ip)
+{
+    if (ts == NULL) {
+        LOG_err("null pointer argument");
+        return false;
+    }
+    X509_VERIFY_PARAM *ts_vpm = X509_STORE_get0_param(ts);
+
+    /* first clear any host names, IP addresses, and email addresses */
+    if (
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+        !STORE_set1_host(ts, 0) ||
+# endif
+        !X509_VERIFY_PARAM_set1_host(ts_vpm, 0, 0)
+        || !X509_VERIFY_PARAM_set1_ip(ts_vpm, 0, 0)
+        || !X509_VERIFY_PARAM_set1_email(ts_vpm, 0, 0)) {
+        LOG_err("Could not clear host name and IP address from store");
+        return false;
+    }
+
+    if (name == NULL && ip == NULL)
+        return true;
+
+    char *name_str = CONN_get_host(name);
+    if (name != NULL && name_str == NULL)
+        return false;
+
+    char *ip_str = CONN_get_host(ip);
+    if (ip != NULL && ip_str == NULL) {
+        OPENSSL_free(name_str);
+        return false;
+    }
+
+    X509_VERIFY_PARAM_set_hostflags(ts_vpm,
+                                    X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT |
+                                    X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    bool res = true;
+    if (ip_str != NULL && !X509_VERIFY_PARAM_set1_ip_asc(ts_vpm, ip_str))
+        res = false;
+    if (name_str != NULL && (ip_str == NULL || (res && strcmp(name, ip) == 0))) {
+        res = X509_VERIFY_PARAM_set1_host(ts_vpm, name_str, 0) != 0;
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+        /*
+         * Before OpenSSL 3.0, there was no API function for retrieving the
+         * hostname/ip entries in X509_VERIFY_PARAM. So we stored the host value
+         * in ex_data for use in CREDENTIALS_print_cert_verify_cb().
+         * Since OpenSSL 3.0, this is no more needed as X509_VERIFY_PARAM_get0_host() is available.
+         */
+        if (res)
+            res = STORE_set1_host(ts, name_str);
+# endif
+    }
+    if (!res)
+        LOG(FL_ERR, "Could not set host name '%s' and/or IP address '%s' in store",
+            name_str != NULL ? name_str : "", ip_str != NULL ? ip_str : "");
+    OPENSSL_free(ip_str);
+    OPENSSL_free(name_str);
+    return res;
+}
+
+const char *STORE_get0_host(const X509_STORE *store)
+{
+# if OPENSSL_VERSION_NUMBER < OPENSSL_V_3_0_0
+    /*
+     * Before OpenSSL 3.0, there is no OpenSSL API function for retrieving the
+     * hostname/ip entries in X509_VERIFY_PARAM.
+     * We could use ex_data, but do not support this with GENCMP_NO_SECUTILS.
+     */
+    (void)store; /* prevent compiler warning on unused parameter */
+    return false;
+# else
+    /* first hostname set in store vpm: */
+    return X509_VERIFY_PARAM_get0_host(X509_STORE_get0_param(store), 0);
+# endif
+}
+
+#endif /* ndef GENCMP_NO_TLS */


### PR DESCRIPTION
To support scenarios where only the minimal set of genCMPClient core API functions is needed