### PR TITLE
Fix implicit declaration of FILES_check_icv

### DIFF
--- a/src/credential_loading.c
+++ b/src/credential_loading.c
@@ -23,6 +23,7 @@
 #include <secutils/connections/conn.h> /* for CONN_IS_HTTP[S] */
 #include <secutils/certstatus/crls.h> /* for CONN_load_crl_http */
 #include <secutils/util/log.h>
+#include <secutils/storage/files_icv.h>
 #include <genericCMPClient.h> /* for CRLs_free() */
 
 #include "credential_loading.h"


### PR DESCRIPTION
This was found during building for Debian 13(trixie) and breaks the build with the following message:

/build/reproducible-path/libgencmp-2.0/src/credential_loading.c: In function ‘STORE_load_more_check_ex’: /build/reproducible-path/libgencmp-2.0/src/credential_loading.c:902:12: error: implicit declaration of function ‘FILES_check_icv’ [-Wimplicit-function-declaration]
  902 |         || FILES_check_icv(ctx, file)
      |            ^~~~~~~~~~~~~~~
